### PR TITLE
CommandHandler Exception Handling

### DIFF
--- a/plugins/scxml/hu.bme.mit.gamma.scxml.transformation.commandhandler/src/hu/bme/mit/gamma/scxml/transformation/commandhandler/CommandHandler.java
+++ b/plugins/scxml/hu.bme.mit.gamma.scxml.transformation.commandhandler/src/hu/bme/mit/gamma/scxml/transformation/commandhandler/CommandHandler.java
@@ -114,8 +114,10 @@ public class CommandHandler extends AbstractHandler {
 				}
 			}
 		}
-		catch (IOException e) {
-				e.printStackTrace();
+		catch (Exception exception) {
+			exception.printStackTrace();
+			logger.log(Level.SEVERE, exception.getMessage());
+			DialogUtil.showErrorWithStackTrace(exception.getMessage(), exception);
 		}
 		return null;
 	}


### PR DESCRIPTION
When I tried to generate a .gcd file, it produced an error, but the Exception was too specific (IOException) and the program didn't print any relevant error messages. To fix this problem, I exchanged the Exception type to a more general one. 
Are there any reasons you only caught IOExceptions?